### PR TITLE
Rclick interact

### DIFF
--- a/src/main/java/sdu/student/FXMLController.java
+++ b/src/main/java/sdu/student/FXMLController.java
@@ -113,12 +113,6 @@ public class FXMLController implements Initializable {
         String javafxVersion = System.getProperty("javafx.version");
         label.setText("Hello, JavaFX " + javafxVersion + "\nRunning on Java " + javaVersion + ".");
 
-        //Configure custom PrintStream
-        System.setOut(printStream);
-        printStream.printListProperty().addListener((observable, oldValue, newValue) -> {
-            Platform.runLater(() -> displayTextMessage(newValue.get(newValue.size() - 1), textDisplayDeletionDelay));
-        });
-
         loadedImages = getImages(spriteDirectory, getClass());
         loadGame();
 
@@ -131,6 +125,12 @@ public class FXMLController implements Initializable {
 
 
 
+
+        //Configure custom PrintStream
+        System.setOut(printStream);
+        printStream.printListProperty().addListener((observable, oldValue, newValue) -> {
+            Platform.runLater(() -> displayTextMessage(newValue.get(newValue.size() - 1), textDisplayDeletionDelay));
+        });
 
     }
 

--- a/src/main/java/sdu/student/FXMLController.java
+++ b/src/main/java/sdu/student/FXMLController.java
@@ -113,6 +113,12 @@ public class FXMLController implements Initializable {
         String javafxVersion = System.getProperty("javafx.version");
         label.setText("Hello, JavaFX " + javafxVersion + "\nRunning on Java " + javaVersion + ".");
 
+        //Configure custom PrintStream
+        System.setOut(printStream);
+        printStream.printListProperty().addListener((observable, oldValue, newValue) -> {
+            Platform.runLater(() -> displayTextMessage(newValue.get(newValue.size() - 1), textDisplayDeletionDelay));
+        });
+
         loadedImages = getImages(spriteDirectory, getClass());
         loadGame();
 
@@ -123,11 +129,7 @@ public class FXMLController implements Initializable {
 
         enableGameUpdater();
 
-        //Configure custom PrintStream
-        System.setOut(printStream);
-        printStream.printListProperty().addListener((observable, oldValue, newValue) -> {
-           Platform.runLater(() -> displayTextMessage(newValue.get(newValue.size() - 1), textDisplayDeletionDelay));
-        });
+
 
 
     }
@@ -442,23 +444,40 @@ public class FXMLController implements Initializable {
 
     public void roomPaneClicked(MouseEvent mouseEvent) {
 
-        if (mouseEvent.getButton() == MouseButton.SECONDARY){
+        selectedGamePosition = positionClickedOnPane(getBackgroundTileDim(), getBackgroundTileDim(), mouseEvent.getX(), mouseEvent.getY());
+        if (selectedGamePosition.getX() < 0 || selectedGamePosition.getY() < 0 || selectedGamePosition.getX() > getBackgroundRowCount() || selectedGamePosition.getY() > getBackgroundRowCount()) {
+            return;
+        }
 
-            selectedGamePosition = positionClickedOnPane(getBackgroundTileDim(), getBackgroundTileDim(), mouseEvent.getX(), mouseEvent.getY());
-            if (selectedGamePosition.getX() < 0 || selectedGamePosition.getY() < 0 || selectedGamePosition.getX() > getBackgroundRowCount() || selectedGamePosition.getY() > getBackgroundRowCount()) {
-                return;
-            }
-
-            try {
-                rightClickGameObject(model.getRoom().getGridGameObject(selectedGamePosition));
-            } catch (ArrayIndexOutOfBoundsException e) { // Handle exceptions caused by non-matching RoomGrid sizes or invalid positions
-                System.out.println(e.getMessage());
+        if (vectorDifference(model.getPlayer().getPos(), selectedGamePosition) == 1) {
+            switch (mouseEvent.getButton()) {
+                case PRIMARY -> {
+                    model.interact(selectedGamePosition, false);
+                    faceDirection(vectorDirection(model.getPlayer().getPos(), selectedGamePosition));
+                }
+                case SECONDARY -> {
+                    model.interact(selectedGamePosition, true);
+                    faceDirection(vectorDirection(model.getPlayer().getPos(), selectedGamePosition));
+                }
             }
         }
+
+    }
+
+    private void faceDirection(Direction vectorDirection) {
+        model.getPlayer().setDefaultImage(vectorDirection);
     }
 
 
     private void rightClickGameObject(GameObject object){
+
+               /*
+               call using
+            try {
+                rightClickGameObject(model.getRoom().getGridGameObject(selectedGamePosition));
+            } catch (ArrayIndexOutOfBoundsException e) { // Handle exceptions caused by non-matching RoomGrid sizes or invalid positions
+                System.out.println(e.getMessage());
+            }*/
 
         if(object instanceof Field && selectedGamePosition != null){
 

--- a/src/main/java/worldofzuul/Game.java
+++ b/src/main/java/worldofzuul/Game.java
@@ -324,15 +324,17 @@ public class Game {
     }
 
     private void removeItem(Command command) {
-        int itemIndex = 0;
         if (command.hasItem()) {
             player.getInventory().removeItem(command.getItem());
-            return;
         } else if (command.hasSecondWord()) {
-            itemIndex = tryParse(command.getSecondWord(), 0);
+            player.getInventory().removeItem(tryParse(command.getSecondWord(), 0));
+
         }
 
-        player.getInventory().removeItem(itemIndex);
+        if(!player.getInventory().getItems().contains(player.getInventory().getSelectedItem())){
+            player.getInventory().unselectItem();
+        }
+
     }
 
     private void printHelp() {

--- a/src/main/java/worldofzuul/Game.java
+++ b/src/main/java/worldofzuul/Game.java
@@ -69,6 +69,21 @@ public class Game {
         processCommandInternal(new Command(CommandWord.INTERACT, null));
     }
 
+    public void interact(Vector gameObjectPos, boolean useItem) {
+        Command[] commands;
+        if (useItem) {
+            commands = currentRoom
+                    .getGridGameObject(gameObjectPos)
+                    .interact(player.getInventory().getSelectedItem());
+        } else {
+            commands = currentRoom
+                    .getGridGameObject(gameObjectPos)
+                    .interact();
+            }
+
+       processCommandInternal(commands);
+    }
+
 
 
     public void reconfigureRooms(){

--- a/src/main/java/worldofzuul/Inventory.java
+++ b/src/main/java/worldofzuul/Inventory.java
@@ -27,6 +27,9 @@ public class Inventory {
             return null;
         }
     }
+    public void unselectItem(){
+        selectedItem = null;
+    }
 
     public void setSelectedItem(Item item) {
         if (getItems().contains(item)) {

--- a/src/main/java/worldofzuul/SpriteAnimation.java
+++ b/src/main/java/worldofzuul/SpriteAnimation.java
@@ -162,6 +162,16 @@ public abstract class SpriteAnimation extends Sprite {
         return animationTimeline;
     }
 
+    public void setDefaultImage(Object animationKey){
+        if (imageAnimations.values().size() > 0 && imageAnimations.containsKey(animationKey)) {
+            Image[] images = imageAnimations.get(animationKey);
+            if (images.length > 0) {
+                setImage(images[images.length - 1]);
+                display();
+            }
+        }
+    }
+
     @Override
     public Image getImage() {
         if (super.getImage() != null) {

--- a/src/main/java/worldofzuul/util/MessageHelper.java
+++ b/src/main/java/worldofzuul/util/MessageHelper.java
@@ -30,6 +30,7 @@ public class MessageHelper {
         public static void alreadyPlanted() {
             System.out.println("A plant already exists here.");
         }
+
     }
     public static class Command {
 
@@ -129,6 +130,9 @@ public class MessageHelper {
 
         public static void plantBecameRipe(String plant) {
             System.out.println(plant + " became ripe!");
+        }
+        public static void println(String string){
+            System.out.println(string);
         }
     }
 

--- a/src/main/java/worldofzuul/world/NPC.java
+++ b/src/main/java/worldofzuul/world/NPC.java
@@ -3,6 +3,7 @@ package worldofzuul.world;
 import worldofzuul.item.Item;
 import worldofzuul.item.Plant;
 import worldofzuul.parsing.Command;
+import worldofzuul.util.MessageHelper;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,7 +27,7 @@ public class NPC extends GameObject {
         dialog.add(dialogText);
 
 
-        return super.interact();
+        return null;
     }
 
     @Override

--- a/src/main/java/worldofzuul/world/Quest.java
+++ b/src/main/java/worldofzuul/world/Quest.java
@@ -41,14 +41,24 @@ public class Quest {
         if(turnInClass.isInstance(item)){
             if(item instanceof Consumable){
                 if(((Consumable) item).getRemaining() >= turnInQuantity){
+                    System.out.println("You turned in " +turnInQuantity + " " + item.getName() + "s.");
+
                     ((Consumable) item).deplete(turnInQuantity);
                     commands.addAll(completeQuest());
+
                 } else {
                     turnInQuantity -= ((Consumable) item).getRemaining();
+                    System.out.println("You turned in " + ((Consumable) item).getRemaining() + " " + item.getName() + "s.");
                     ((Consumable) item).deplete(((Consumable) item).getRemaining());
+
+                    if(((Consumable) item).getRemaining() == 0){
+                        commands.add(new Command(CommandWord.REMOVEITEM, null, item));
+                    }
                 }
             } else {
                 commands.add(new Command(CommandWord.REMOVEITEM, null, item));
+                System.out.println("You turned in one " + item.getName());
+
                 turnInQuantity--;
                 if(turnInQuantity <= 0){
                     commands.addAll(completeQuest());


### PR DESCRIPTION
Tilføjer funktionalitet til at kunne højre og venstre klikke på et GameObject nær spilleren, og anvende "interact på det".
Højre klik anvender spillerens selekterede Item, hvorimod venstre klik kalder interact uden et Item.